### PR TITLE
model-registration.md cleanup

### DIFF
--- a/docs/developer-guide/model-registration.md
+++ b/docs/developer-guide/model-registration.md
@@ -4,56 +4,70 @@
 
 ### Concept
 
-Every top-level message from a northbound proto-definition is expected to have its own key which identifies a proto message data.
+Every top-level `message` from a proto definition is expected to have its own key. For example, `message ABF { ...` from the [abf.proto file](https://github.com/ligato/vpp-agent/blob/master/proto/ligato/vpp/abf/abf.proto) requires the generation and registration of a key for accessing ABF information.
 
-The model is explained [here](../user-guide/concepts/#model-specification).
-
-The keys can be structured in one of three ways:
-
-* composite which is most often the case
-* specific containing a unique parameter (e.g. an interface name or a SPD
-* global allowing only one message of the given type to be stored under a global key.
-
-
+A model and proto definition are prerequisites for generating a key. A description of the model, model spec, proto.Messages, and the various types of keys is provided in the [model concepts portion of the user guide](../user-guide/concepts.md#what-is-a-model).
 
 ### Registration
 
-The model is registered to the vpp-agent `spec.go`, in which the key, paths, and names are generated and stored in the registration map. An example registration is illustrated in the `models` package shown here
+The model is registered to the vpp-agent `spec.go`. The key, paths, and names are generated and stored in the registration map. An example registration is illustrated in the `models` package shown here.
 
 ```go
 models.Register(&ProtoMessage{}, models.Spec{
-    Module:  "mp",
+    Module:  "ModuleName",
     Type:    "protomessage",
     Version: "v2",
 })
 ```
 
-The example above registers the `ProtoMessage` type with the given `Spec`. The first parameter is expected to be of the `proto.Message` interface type, the second parameter defines the specification itself. The method `Register` also returns a registration object (which is stored to the registration map in the background) which can be used for easy access to various parts of the model key definition. For example `KeyPrefix()` returns key prefix, `IsKeyValid(<key>)` validates provided key for the given model, etc.
+The example above registers the `ProtoMessage` type with the given `Spec`. The first parameter is a [proto.Message](../user-guide/concepts.md#protomessage). The second parameter defines the [model specification](../user-guide/concepts.md#model-specification). The method `Register` also returns a registration object, which is stored in the registration map. This can be used for easy access to various parts of the model key definition. For example, `KeyPrefix()` returns a key prefix; `IsKeyValid(<key>)` validates the key for the given model.
+
+Here is the registration for ABF:
+```
+var (
+	ModelABF = models.Register(&ABF{}, models.Spec{
+		Module:  "module",
+		Version: "v2",
+		Type:    "abf",
+	}, models.WithNameTemplate("{{.Index}}"))
+)
+```
+Generated long form key:
+```
+/vnf-agent/vpp1/config/vpp/abfs/v2/abf/<index>
+```
+
 
 ### Custom Templates
 
-Registration method has a third optional parameter, which allows passing options for given registration of type `ModelOption`. There is currently only one option available - `models.WithNameTemplate(<template>))`. It allows generating the key with custom identifiers. 
+The registration method defines a third optional parameter. It enables options to be passed for a given registration of type `ModelOption`. There is currently only one option available: `models.WithNameTemplate(<template>))`. This option enables keys with custom identifiers to be generated.
+
+Keys may also be distinguished by the composition of the custom identifier as explained [here.](../user-guide/concepts.md#keys)
 
 **Example 1:**
-A proto model defines a field named `Index` which should be a part of the key as an identifier. We define a custom template to let model registration know that the field should be used:
+
+The proto model defines a field named `Index`, to serve as an identifier in the key. We use a custom template so that model registration will include this field in the key generation process.
 ```go
 models.Register(&ProtoMessage{}, models.Spec{
-    Module:  "mp",
+    Module:  "module",
     Type:    "protomessage",
     Version: "v2",
 }, models.WithNameTemplate("{{.Index}}"))
 ```
 
-The result:
+Generated `specific` long form key:
 ```
-<key-prefix>/<config/status>/<module-path>/<version>/<type>/<index>
+<microservice-label-prefix>/<config/status>/<module>/<version>/<type>/<index>
 ```
  
 !!! note
-    The module path dots are transformed to slashes (`vpp.interfaces` will be shown as `vpp/interfaces` in the key) 
+    The module name dots are transformed to slashes in the key.  For example, `ModuleName = "vpp.abfs"` will be shown as `vpp/abfs` in the key.
  
 **Example 2:**
-Another model cannot be defined with a single unique field, but required a combination of them. Let's assume a proto model with fields `Index` and `Tag` which both need to be used in the key. Define the template as follows:
+
+Other models cannot be defined with a single unique field, but rather require a combination of fields. Consider a proto model with fields `Index` and `Tag`, both of which need to be included in the key.
+
+Define the template as follows:
 ```go
 models.Register(&ProtoMessage{}, models.Spec{
     Module:  "mp",
@@ -62,9 +76,9 @@ models.Register(&ProtoMessage{}, models.Spec{
 }, models.WithNameTemplate("{{.Index}}/tag/{{.Tag}}"))
 ```
 
-The result:
+Generated `composite` long form key:
 ```
-<key-prefix>/<config/status>/<module-path>/<version>/<type>/<index>/tag/<tag>
+<microservice-label-prefix>/<config/status>/<module>/<version>/<type>/<index>/tag/<tag>
 ```
 
 *[SPD]: Security Policy Database

--- a/docs/plugins/db-plugins.md
+++ b/docs/plugins/db-plugins.md
@@ -6,7 +6,7 @@ Datasync defines the interfaces for the abstraction of data synchronization betw
 
 Data synchronization addresses the situation when multiple data sets must by synchronized as a result of a published event.
 
-Examples of components that publish events.
+Examples of components that publish events:
 
 - database upon updates to data
 - message bus consuming messages from Kafka topics
@@ -263,7 +263,7 @@ The Consul plugin provides access to a Consul KV data store.
 
 ### Configuration
 
-Th location of the Consul configuration file can be defined either by the command line flag `consul-config` or set via the `CONSUL_CONFIG` environment variable.
+The location of the Consul configuration file can be defined by the command line flag `consul-config`, or set via the `CONSUL_CONFIG` environment variable.
 
 ### Status Check
 

--- a/docs/plugins/infra-plugins.md
+++ b/docs/plugins/infra-plugins.md
@@ -83,7 +83,7 @@ The idxmap package provides a mapping structure to support the following use-cas
 * Secondary indexing
 * Data caching for a key-value store (such as etcd)
 
-For more detailed description see the godoc reference [here][idxmap-godoc].
+For a more detailed description, see the godoc reference [here][idxmap-godoc].
 
 ### Exposing plugin local data Use-Case
 

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -92,7 +92,7 @@ The combination of the model, and proto.Message are used to define the `protobuf
 
 ![model-proto-KV-store](../img/user-guide/model-proto-KV-store.svg)
 
-If a new object and API for the CNF is required, the developer need only define the model and .proto file. Ligato will generate a key as part of a northbound API for access to the new object. Logic to process the new object in a new or existing function is required as well.
+If a new object and API for the CNF is required, the developer need only define the model and .proto file, and then register the model. Ligato will generate a key as part of a northbound API for access to the new object. Logic to process the new object in a new or existing function is required as well.
 
 ### Name Templates
 


### PR DESCRIPTION
added pointers to concepts.md; added ABF example; used microservice-label-prefix, composite, specific, long-form key terminology from concepts.md; replaced module path with module name where it appeared